### PR TITLE
Fix path join for processing images

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,7 +152,7 @@ if __name__ == '__main__':
     if dir_name:
         for file in os.listdir(dir_name):
             print("Now processing {}".format(file))
-            process_image(dir_name + '\\' + file)
+            process_image(os.path.join(dir_name, file))
     elif img_name:
         process_image(img_name)
 


### PR DESCRIPTION
## Summary
- handle directory separator properly by using `os.path.join` when processing images

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6847ff613728832989ff47717c381eaa